### PR TITLE
New module: win_listen_ports_facts

### DIFF
--- a/plugins/modules/win_listen_ports_facts.ps1
+++ b/plugins/modules/win_listen_ports_facts.ps1
@@ -1,0 +1,80 @@
+#!powershell
+
+# Copyright: (c) 2022, DataDope (@datadope-io)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        date_format = @{ type = 'str'; default = '%c' }
+        tcp_filter = @{ type = 'list'; default = 'Listen' }
+    }
+    supports_check_mode = $false
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$date_format = $module.Params.date_format
+$tcp_filter = $module.Params.tcp_filter
+
+# Structure of the response the script will return
+$ansibleFacts = @{
+    tcp_listen = @()
+    udp_listen = @()
+}
+
+# Build an index of the processes based on the PID
+$processes = @{}
+Get-Process -IncludeUserName | ForEach-Object {
+    $processes[$_.Id] = $_
+}
+
+# Format the given date with the same format as listen_port_facts stime (Date and time - abbreviated) by default, or
+# with the given format
+function Format-Date {
+    param (
+        $date
+    )
+
+    if ($date -ne $null) {
+        $date = Get-Date $date -UFormat $date_format
+    }
+
+    return $date
+}
+
+# Return the processed listener and the associated PID data
+function Build-Listener {
+    param (
+        $listener,
+        $type
+    )
+
+    return @{
+        address = $listener.LocalAddress
+        name = $processes[[int]$listener.OwningProcess].ProcessName
+        pid = $listener.OwningProcess
+        port = $listener.LocalPort
+        protocol = $type
+        stime = Format-Date $processes[[int]$listener.OwningProcess].StartTime
+        user = $processes[[int]$listener.OwningProcess].UserName
+    }
+}
+
+try {
+    # Retrieve the information of the TCP ports with Listen status by default, or with the given state/s
+    Get-NetTCPConnection -State $tcp_filter -ErrorAction SilentlyContinue | Foreach-Object {
+        $ansibleFacts.tcp_listen += Build-Listener $_ "tcp"
+    }
+
+    # Retrieve the information of the UDP ports
+    Get-NetUDPEndpoint | Foreach-Object {
+        $ansibleFacts.udp_listen += Build-Listener $_ "udp"
+    }
+} catch {
+    $module.FailJson("An error occurred while retrieving ports facts: $($_.Exception.Message)", $_)
+}
+
+$module.Result.ansible_facts = $ansibleFacts
+$module.ExitJson()

--- a/plugins/modules/win_listen_ports_facts.py
+++ b/plugins/modules/win_listen_ports_facts.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, DataDope (@datadope-io)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_listen_ports_facts
+short_description: Recopilates the facts of the listening ports of the machine
+description:
+    - Recopilates the information of the TCP and UDP ports of the machine and
+      the related processes.
+    - State of the TCP ports could be filtered, as well as the format of the
+      date when the parent process was launched.
+    - The module's goal is to replicate the functionality of the linux module
+      listen_ports_facts, mantaining the format of the said module.
+options:
+  date_format:
+    description:
+      - The format of the date when the process that owns the port started.
+      - The date specification is UFormat
+    type: str
+    default: %c
+  tcp_filter:
+    description:
+      - Filter for the state of the TCP ports that will be recopilated.
+      - Supports multiple states, which should be among the following ones:
+        - Bound
+        - Closed
+        - CloseWait
+        - Closing
+        - DeleteTCB
+        - Established
+        - FinWait1
+        - FinWait2
+        - LastAck
+        - Listen
+        - SynReceived
+        - SynSent
+        - TimeWait
+    type: list
+    elements: str
+    default: [ Listen ]
+notes:
+- The generated data (tcp_listen and udp_listen) and the fields within follows
+  the listen_ports_facts schema to achieve compatibility with the said module 
+  output, even though this module if capable of extracting ports with a state
+  other than Listen
+seealso:
+- module: community.general.listen_ports_facts
+author:
+- David Nieto (@david-ns)
+'''
+
+EXAMPLES = r'''
+- name: Recopilate ports facts
+  ansible.windows.win_listen_ports_facts:
+
+- name: Retrieve only ports with Closing and Established states
+  ansible.windows.win_listen_ports_facts:
+    tcp_filter:
+        - Closing
+        - Established
+
+- name: Get ports facts with only the year within the date field
+  ansible.windows.win_listen_ports_facts:
+    date_format: '%Y'
+'''
+
+RETURN = r'''
+tcp_listen:
+    description: List of dicts with the detected TCP ports, each one with the
+        following data:
+        - address: Listening address
+        - name: Name of the parent process
+        - pid: ID of the parent process
+        - port: Listening port
+        - protocol: Listening protocol (tcp)
+        - stime: Launch date of the parent process
+        - user: User owner of the parent process
+    returned: success
+    type: list
+    sample: [
+        {
+            "address": "127.0.0.1",
+            "name": "python",
+            "pid": 5332,
+            "port": 82,
+            "protocol": "tcp",
+            "stime": "Thu Nov 18 15:27:42 2021",
+            "user": "SERVER\\Administrator"
+        }
+    ]
+udp_listen:
+    description: List of dicts with the detected UDP ports, each one with the
+        following data:
+        - address: Listening address
+        - name: Name of the parent process
+        - pid: ID of the parent process
+        - port: Listening port
+        - protocol: Listening protocol (udp)
+        - stime: Launch date of the parent process
+        - user: User owner of the parent process
+    returned: success
+    type: list
+    sample: [
+        {
+            "address": "127.0.0.1",
+            "name": "python",
+            "pid": 5332,
+            "port": 82,
+            "protocol": "udp",
+            "stime": "Thu Nov 18 15:27:42 2021",
+            "user": "SERVER\\Administrator"
+        }
+    ]
+'''

--- a/tests/integration/targets/win_listen_ports_facts/aliases
+++ b/tests/integration/targets/win_listen_ports_facts/aliases
@@ -1,0 +1,1 @@
+windows/adds/group1

--- a/tests/integration/targets/win_listen_ports_facts/tasks/main.yml
+++ b/tests/integration/targets/win_listen_ports_facts/tasks/main.yml
@@ -1,0 +1,45 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2022, DataDope (@datadope-io)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Gather facts with invalid tcp_filter state and null date format
+  win_listen_ports_facts:
+    tcp_filter:
+      - Error
+    date_format: null
+  register: invalid_state_date_run
+  ignore_errors: True
+
+- name: Gather facts with only some invalid tcp_filter states and null date format
+  win_listen_ports_facts:
+    tcp_filter:
+      - Bound
+      - Listen
+      - Error
+    date_format: null
+  register: partial_invalid_state_date_run
+  ignore_errors: True
+
+- name: Gather facts with multiple filters and custom date format
+  win_listen_ports_facts:
+    tcp_filter:
+      - Bound
+      - Listen
+    date_format: yyyy
+  register: custom_state_date_run
+  ignore_errors: True
+
+- name: Gather facts with multiple filters and custom date format
+  win_listen_ports_facts:
+  register: default_run
+  ignore_errors: True
+
+- assert:
+    that:
+    - invalid_state_date_run.failed is defined and invalid_state_date_run.failed
+    - partial_invalid_state_date_run.failed is defined and partial_invalid_state_date_run.failed
+    - custom_state_date_run.failed is not defined or not custom_state_date_run.failed
+    - default_run.failed is not defined or not default_run.failed
+    - tcp_listen is defined
+    - udp_listen is defined


### PR DESCRIPTION
##### SUMMARY
New module win_listen_ports_facts to gather information about the ports of the machine

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
- win_listen_ports_facts

##### ADDITIONAL INFORMATION
- Recopilates the information of the TCP and UDP ports of the machine and the related processes.
- State of the TCP ports could be filtered, as well as the format of the date when the parent process was launched.
- The module's goal is to replicate the functionality of the linux module listen_ports_facts (community.general.listen_ports_facts), mantaining the format of the said module.